### PR TITLE
Allow "alg" to not be specified

### DIFF
--- a/pyjwt_key_fetcher/key.py
+++ b/pyjwt_key_fetcher/key.py
@@ -18,7 +18,9 @@ class Key(collections.abc.Mapping):
         self.__kid = pyjwt.key_id
 
         self.key: PyJWK = pyjwt.key
-        self.algorithms = [jwk_data["alg"]]
+        self.algorithms = []
+        if "alg" in jwk_data:
+            self.algorithms.append(jwk_data["alg"])
 
     @property
     def dct(self) -> Dict[str, Any]:


### PR DESCRIPTION
"alg" is optional in the spec (https://datatracker.ietf.org/doc/html/rfc7517#section-4.4), and indeed not included by all providers. I'm just testing with Azure, which does not include it.

Thanks a lot for putting together this library btw.! 